### PR TITLE
Crawl source information per item/page

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -74,3 +74,30 @@ com,toscrape,quotes)/static/main.css 20241007081525074 {...}
 > com,toscrape,quotes)/tag/simile/ 20241007081524944 {...}
 > com,toscrape,quotes)/tag/truth/ 20241007081523804 {...}
 ```
+
+## Requests and Responses
+
+## Special Keys in Request.meta
+
+The `Request.meta` attribute in Scrapy allows you to store arbitrary data for use during the crawling process. While you can store any custom data in this attribute, Scrapy and its built-in extensions recognize certain special keys. Additionally, the `scrapy-webarchive` extension introduces its own special key for managing metadata. Below is a description of the key used by `scrapy-webarchive`:
+
+* `webarchive_warc`
+
+### `webarchive_warc`
+This key stores the result of a WACZ crawl or export. The data associated with this key is read-only and is not used to control Scrapy's behavior. The value of this key can be accessed using the constant `WEBARCHIVE_META_KEY`, but direct usage of this constant is discouraged. Instead, you should use the provided class method to instantiate a metadata object, as shown in the example below:
+
+```python
+from scrapy_webarchive.models import WarcMetadata
+
+
+def parse_function(self, response):
+    # Instantiate a WarcMetadata object from the response
+    warc_meta = WarcMetadata.from_response(response)
+
+    # Extract the attributes to attach while parsing a page/item
+    if warc_meta:
+        yield {
+            'warc_record_id': warc_meta.record_id,
+            'wacz_uri': warc_meta.wacz_uri,
+        }
+```

--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -49,7 +49,7 @@ SW_WACZ_CRAWL = True
 
 Not all URLs will be interesting for the crawl since your WACZ will most likely contain static files such as fonts, JavaScript (website and external), stylesheets, etc. In order to improve the performance of the spider by not reading all the irrelevant request/response entries, you can configure the following atrribute in your spider, `archive_regex`:
 
-``` py title="my_wacz_spider.py"
+``` py title="my_wacz_spider.py" hl_lines="6"
 from scrapy.spiders import Spider
 
 
@@ -89,7 +89,7 @@ The `Request.meta` attribute in Scrapy allows you to store arbitrary data for us
 #### `webarchive_warc`
 This key stores the result of a WACZ crawl or export. The data associated with this key is read-only and is not used to control Scrapy's behavior. The value of this key can be accessed using the constant `WEBARCHIVE_META_KEY`, but direct usage of this constant is discouraged. Instead, you should use the provided class method to instantiate a metadata object, as shown in the example below:
 
-``` py title="my_wacz_spider.py"
+``` py title="my_wacz_spider.py" hl_lines="10"
 from scrapy.spiders import Spider
 from scrapy_webarchive.models import WarcMetadata
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,14 +2,20 @@
 
 To install `scrapy-webarchive`, run:
 
-```bash
+``` bash
 pip install scrapy-webarchive
 ```
 
 If you want to use a cloud provider for storing/scraping, you opt-in to install these dependencies:
 
-```bash
+``` bash
 pip install scrapy-webarchive[aws]
+```
+
+``` bash
 pip install scrapy-webarchive[gcs]
+```
+
+``` bash
 pip install scrapy-webarchive[all]
 ```

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,7 +6,7 @@
 
 ### `SW_EXPORT_URI`
 
-```python
+``` py title="settings.py"
 # Either configure the directory where the output should be uploaded to
 SW_EXPORT_URI = "s3://scrapy-webarchive/"
 SW_EXPORT_URI = "s3://scrapy-webarchive/{spider}/"
@@ -45,7 +45,7 @@ This setting defines the description of the WACZ used in the `datapackage.json`,
 
 ⚠️ Scraping against a remote source currently only supports AWS S3.
 
-```python
+``` py title="settings.py"
 # "file://" must be explicitly added, unlike SW_EXPORT_URI where it makes an assumption if no scheme is added.
 SW_WACZ_SOURCE_URI = "file:///Users/username/Documents/archive.wacz"
 SW_WACZ_SOURCE_URI = "s3://scrapy-webarchive/archive.wacz"
@@ -58,7 +58,7 @@ This setting defines the location of the WACZ file that should be used as a sour
 
 ### `SW_WACZ_CRAWL`
 
-```python
+``` py title="settings.py"
 SW_WACZ_CRAWL = True
 ```
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -62,4 +62,4 @@ This setting defines the location of the WACZ file that should be used as a sour
 SW_WACZ_CRAWL = True
 ```
 
-Setting to ignore original `start_requests`, just yield all responses found in WACZ.
+Setting to ignore original `start_requests`, just yield all responses found in WACZ. For more information see [Iterating a WACZ archive index](advanced_usage.md#iterating-a-wacz-archive-index).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,7 +11,7 @@ The general use for this plugin is separated in two parts, exporting and crawlin
 
 To archive the requests/responses during a crawl job you need to enable the `WaczExporter` extension. 
 
-```python
+``` py title="settings.py"
 EXTENSIONS = {
     "scrapy_webarchive.extensions.WaczExporter": 543,
 }
@@ -19,7 +19,7 @@ EXTENSIONS = {
 
 This extension also requires you to set the export location using the `SW_EXPORT_URI` settings (check the settings page for different options for exporting).
 
-```python
+``` py title="settings.py"
 SW_EXPORT_URI = "s3://scrapy-webarchive/"
 ```
 
@@ -33,7 +33,7 @@ To crawl against a WACZ archive you need to use the `WaczMiddleware` downloader 
 
 To use the downloader middleware, enable it in the settings like so:
 
-```python
+``` py title="settings.py"
 DOWNLOADER_MIDDLEWARES = {
     "scrapy_webarchive.downloadermiddlewares.WaczMiddleware": 543,
 }
@@ -41,7 +41,7 @@ DOWNLOADER_MIDDLEWARES = {
 
 Then define the location of the WACZ archive with `SW_WACZ_SOURCE_URI` setting:
 
-```python
+``` py title="settings.py"
 SW_WACZ_SOURCE_URI = "s3://scrapy-webarchive/archive.wacz"
 SW_WACZ_CRAWL = True
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -43,5 +43,4 @@ Then define the location of the WACZ archive with `SW_WACZ_SOURCE_URI` setting:
 
 ``` py title="settings.py"
 SW_WACZ_SOURCE_URI = "s3://scrapy-webarchive/archive.wacz"
-SW_WACZ_CRAWL = True
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,10 @@ site_url: https://github.com/q-m/scrapy-webarchive
 
 theme:
   name: material
+  features:
+    - content.code.copy
+    - content.code.select
+    - content.code.annotate
 
 nav:
   - Introduction: index.md
@@ -12,3 +16,12 @@ nav:
       - Usage: usage.md
       - Advanced Usage: advanced_usage.md
   - Settings: settings.md
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/scrapy_webarchive/downloadermiddlewares.py
+++ b/scrapy_webarchive/downloadermiddlewares.py
@@ -56,11 +56,10 @@ class WaczMiddleware(BaseWaczMiddleware):
         if not warc_record:
             self.stats.inc_value("webarchive/response_not_found", spider=spider)
             return Response(url=request.url, status=404)
-        
-        request.meta["warc_record_response"] = warc_record
-        
+
         # Record found, try to re-create a response from it.
         response = record_transformer.response_for_record(warc_record, request)
+        response.meta["response_origin"] = warc_record
 
         if not response:
             self.stats.inc_value("webarchive/response_not_recognized", spider=spider)

--- a/scrapy_webarchive/downloadermiddlewares.py
+++ b/scrapy_webarchive/downloadermiddlewares.py
@@ -57,8 +57,10 @@ class WaczMiddleware(BaseWaczMiddleware):
             self.stats.inc_value("webarchive/response_not_found", spider=spider)
             return Response(url=request.url, status=404)
         
+        request.meta["warc_record_response"] = warc_record
+        
         # Record found, try to re-create a response from it.
-        response = record_transformer.response_for_record(warc_record)
+        response = record_transformer.response_for_record(warc_record, request)
 
         if not response:
             self.stats.inc_value("webarchive/response_not_recognized", spider=spider)

--- a/scrapy_webarchive/extensions.py
+++ b/scrapy_webarchive/extensions.py
@@ -61,11 +61,19 @@ class WaczExporter:
         self.spider_name = crawler.spidercls.name if hasattr(crawler.spidercls, "name") else crawler.spider.name
 
         # Get the store URI and configure the WACZ filename
-        store_uri, self.wacz_fname  = self._retrieve_store_uri_and_wacz_fname()
+        self.store_uri, self.wacz_fname  = self._retrieve_store_uri_and_wacz_fname()
 
-        # Initialize store and writer
-        self.store: FilesStoreProtocol = self._get_store(store_uri)
+        # Initialize store, writer and creator
+        self.store: FilesStoreProtocol = self._get_store(self.store_uri)
         self.writer = WarcFileWriter(collection_name=self.spider_name)
+        self.wacz_creator = WaczFileCreator(
+            store=self.store,
+            warc_fname=self.writer.warc_fname,
+            wacz_fname=self.wacz_fname,
+            collection_name=crawler.spider.name,
+            title=self.settings["SW_WACZ_TITLE"],
+            description=self.settings["SW_WACZ_DESCRIPTION"],
+        )
 
     def _check_configuration_prerequisites(self) -> None:
         """raises NotConfigured if essential settings or middleware configurations are incorrect."""
@@ -143,27 +151,27 @@ class WaczExporter:
         request.meta["WARC-Date"] = get_formatted_dt_string(format=WARC_DT_FORMAT)
 
         # Write response WARC record
-        record = self.writer.write_response(response, request)
+        response_record = self.writer.write_response(response, request)
         self.stats.inc_value("webarchive/exporter/response_written", spider=spider)
         self.stats.inc_value(
-            f"webarchive/exporter/writer_status_count/{record.http_headers.get_statuscode()}", 
+            f"webarchive/exporter/writer_status_count/{response_record.http_headers.get_statuscode()}", 
             spider=spider,
         )
 
         # Write request WARC record
-        self.writer.write_request(request, concurrent_to=record)
+        request_record = self.writer.write_request(request, concurrent_to=response_record)
         self.stats.inc_value("webarchive/exporter/request_written", spider=spider)
 
+        request.meta['exported_warc_response'] = response_record
+        request.meta['exported_warc_request'] = request_record
+        request.meta['exported_wacz_uri'] = self.export_uri
+
     def spider_closed(self, spider: Spider) -> None:
-        wacz_creator = WaczFileCreator(
-            store=self.store,
-            warc_fname=self.writer.warc_fname,
-            wacz_fname=self.wacz_fname,
-            collection_name=spider.name,
-            title=self.settings["SW_WACZ_TITLE"],
-            description=self.settings["SW_WACZ_DESCRIPTION"],
-        )
-        wacz_creator.create()
+        self.wacz_creator.create()
+
+    @property
+    def export_uri(self) -> str:
+        return os.path.join(self.store_uri, self.wacz_creator.wacz_fname)
 
 
 def get_archive_uri_template_dt_variables() -> dict:

--- a/scrapy_webarchive/models.py
+++ b/scrapy_webarchive/models.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Union
+
+from scrapy.http.response import Response
+
+from scrapy_webarchive.utils import WEBARCHIVE_META_KEY
+
+
+@dataclass
+class WarcMetadata:
+    """
+    Encapsulates metadata about the WARC record.
+
+    Attributes:
+        action (str): The action performed ("read" or "write").
+        record_id (str): The unique ID of the WARC record.
+        wacz_uri (str): The URI of the WACZ file.
+    """
+    action: str
+    record_id: str
+    wacz_uri: str
+
+    def to_dict(self) -> dict:
+        """Convert the object to a dictionary for compatibility with Scrapy's meta."""
+
+        return {
+            "action": self.action,
+            "record_id": self.record_id,
+            "wacz_uri": self.wacz_uri,
+        }
+    
+    @classmethod
+    def from_response(cls, response: Response) -> Union["WarcMetadata", None]:
+        """Create a WarcMetadata instance from a Scrapy response object."""
+
+        if not hasattr(response, "meta"):
+            return None
+
+        warc_meta = response.meta.get(WEBARCHIVE_META_KEY)
+
+        if not warc_meta:
+            return None
+
+        return cls(**warc_meta)

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 WARC_DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TIMESTAMP_DT_FORMAT = "%Y%m%d%H%M%S"
 BUFF_SIZE = 1024 * 64
+WEBARCHIVE_META_KEY = "webarchive_warc"
 
 logger = logging.getLogger(__name__)
 

--- a/scrapy_webarchive/wacz/storages.py
+++ b/scrapy_webarchive/wacz/storages.py
@@ -35,6 +35,13 @@ class ZipStorageHandler(ABC):
 
         pass
 
+    @property
+    @abstractmethod
+    def uri(self) -> str:
+        """The URI of the ZIP file."""
+
+        pass
+
 
 class LocalZipStorageHandler(ZipStorageHandler):
     """Handles ZIP files stored locally."""
@@ -42,8 +49,8 @@ class LocalZipStorageHandler(ZipStorageHandler):
     def __init__(self, uri: str):
         """Initialize the handler with a local ZIP file."""
 
-        self.uri = uri
-        parsed_uri = urlparse(self.uri)
+        self._uri = uri
+        parsed_uri = urlparse(uri)
         self.file_path = unquote(parsed_uri.path)
 
         if not self.zip_exists:
@@ -77,6 +84,10 @@ class LocalZipStorageHandler(ZipStorageHandler):
     @property
     def zip_exists(self) -> bool:
         return os.path.exists(self.file_path)
+    
+    @property
+    def uri(self) -> str:
+        return self._uri
 
 
 class RemoteZipStorageHandler(ZipStorageHandler):
@@ -163,6 +174,7 @@ class S3ZipStorageHandler(RemoteZipStorageHandler):
         if parse_result.scheme != "s3":
             raise ValueError(f"Incorrect URI scheme in {uri}, expected 's3'")
 
+        self._uri = uri
         self.bucket = parse_result.netloc
         self.path = parse_result.path.lstrip("/")
         self.s3_client = self._initialize_s3_client()
@@ -209,6 +221,10 @@ class S3ZipStorageHandler(RemoteZipStorageHandler):
     @property
     def zip_exists(self) -> bool:
         return bool(self.get_file_info())
+
+    @property
+    def uri(self) -> str:
+        return self._uri
 
 
 class ZipStorageHandlerFactory:

--- a/scrapy_webarchive/wacz/wacz_file.py
+++ b/scrapy_webarchive/wacz/wacz_file.py
@@ -50,13 +50,16 @@ class WaczFile:
         warc_part = BytesIO(file_part)
         return WARCReader(warc_part).read_record()
 
-    def get_warc_from_url(self, url: str) -> Tuple[Union[WARCRecord, None], Union[CdxjRecord, None]]:
+    def get_warc_from_url(self, url: str) -> Union[Tuple[WARCRecord, CdxjRecord], Tuple[None, None]]:
         """Retrieves a WARC record from the WACZ archive by searching for the URL in the index."""
 
         cdxj_record = self._find_in_index(url)
 
         if cdxj_record:
-            return self.get_warc_from_cdxj_record(cdxj_record), cdxj_record
+            warc_record = self.get_warc_from_cdxj_record(cdxj_record)
+
+            if warc_record:
+                return warc_record, cdxj_record
         
         return None, None
 
@@ -113,12 +116,12 @@ class MultiWaczFile:
 
         return cdxj_record.wacz_file.get_warc_from_cdxj_record(cdxj_record) if cdxj_record.wacz_file else None
         
-    def get_warc_from_url(self, url: str) -> Tuple[Union[WARCRecord, None], Union[CdxjRecord, None]]:
+    def get_warc_from_url(self, url: str) -> Union[Tuple[WARCRecord, CdxjRecord], Tuple[None, None]]:
         """Searches through all WACZ files to find a WARC record that matches the provided URL."""
 
         for wacz in self.waczs:
             warc_record, cdxj_record = wacz.get_warc_from_url(url)
-            if warc_record:
+            if warc_record and cdxj_record:
                 return warc_record, cdxj_record
 
         return None, None

--- a/scrapy_webarchive/warc.py
+++ b/scrapy_webarchive/warc.py
@@ -185,7 +185,7 @@ class WarcRecordTransformer:
         # TODO: locate request in WACZ and include all relevant things (like headers)
         return Request(url=cdxj_record.data["url"], method=cdxj_record.data.get("method", "GET"), **kwargs)
 
-    def response_for_record(self, warc_record: WARCRecord, **kwargs):
+    def response_for_record(self, warc_record: WARCRecord, request: Request, **kwargs):
         """Create a Scrapy response instance from a WARCRecord."""
 
         # We expect a response.
@@ -220,6 +220,7 @@ class WarcRecordTransformer:
 
         return response_cls(
             url=warc_record.url,
+            request=request,
             status=int(status.decode()),
             protocol=protocol.decode(),
             headers=headers,

--- a/scrapy_webarchive/warc.py
+++ b/scrapy_webarchive/warc.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import socket
 import uuid
 from io import BytesIO
+from typing import Union
 from urllib.parse import urlparse
 
 from scrapy import __version__ as scrapy_version
 from scrapy.http.request import Request
 from scrapy.http.response import Response
 from scrapy.responsetypes import ResponseTypes
-from typing_extensions import List, Optional, Tuple
+from typing_extensions import List, Tuple
 from warc import WARCReader as BaseWARCReader
 from warc.warc import WARCRecord
 from warcio.recordloader import ArcWarcRecord
@@ -47,7 +48,7 @@ class WarcFileWriter:
 
     WARC_VERSION = WARCWriter.WARC_1_1
 
-    def __init__(self, collection_name: str, warc_fname: Optional[str] = None) -> None:
+    def __init__(self, collection_name: str, warc_fname: Union[str, None] = None) -> None:
         self.collection_name = collection_name
         self.warc_fname = warc_fname or generate_warc_fname(prefix=collection_name)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 import pytest
-from scrapy.http import Response, Request
+from scrapy.http import Request, Response
 
 from scrapy_webarchive.models import WarcMetadata
 from scrapy_webarchive.utils import WEBARCHIVE_META_KEY

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,47 @@
+import pytest
+from scrapy.http import Response, Request
+
+from scrapy_webarchive.models import WarcMetadata
+from scrapy_webarchive.utils import WEBARCHIVE_META_KEY
+
+
+class TestWarcMetadata:
+    def setup_method(self):
+        self.meta = {
+            "action": "read",
+            "record_id": "12345",
+            "wacz_uri": "s3://example/archive.wacz",
+        }
+
+    def test_warc_metadata_to_dict(self):
+        result = WarcMetadata(**self.meta).to_dict()
+        assert result == self.meta
+
+    def test_warc_metadata_from_response_valid(self):
+        warc_metadata = WarcMetadata.from_response(self._get_response())
+        assert isinstance(warc_metadata, WarcMetadata)
+        assert warc_metadata.action == "read"
+        assert warc_metadata.record_id == "12345"
+        assert warc_metadata.wacz_uri == "s3://example/archive.wacz"
+
+    def test_warc_metadata_from_response_no_meta(self):
+        response = self._get_response(meta={})
+        warc_meta = WarcMetadata.from_response(response)
+        assert warc_meta is None
+
+    def test_warc_metadata_from_response_no_warc_meta(self):
+        response = self._get_response(meta={"key": "value"})
+        warc_meta = WarcMetadata.from_response(response)
+        assert warc_meta is None
+
+    def test_warc_metadata_from_response_invalid_meta(self):
+        response = self._get_response(meta={WEBARCHIVE_META_KEY: {"invalid_key": "value"}})
+        with pytest.raises(TypeError):
+            WarcMetadata.from_response(response)
+    
+    def _get_response(self, meta: dict = None, url: str = "https://example.com"):
+        if meta is None:
+            meta = {WEBARCHIVE_META_KEY: self.meta}
+
+        request = Request(url=url, meta=meta)
+        return Response(url=url, request=request)

--- a/tests/test_warc.py
+++ b/tests/test_warc.py
@@ -44,7 +44,7 @@ class TestWarcRecordTransformer:
             surt="com,example)/index",
             host="example",
             data={
-            "url": "http://example.com", 
+                "url": "http://example.com", 
                 "mime": "text/html", 
                 "status": "200", 
                 "digest": "sha1:AA7J5JETQ4H7GG22MU2NCAUO6LM2EPEU", 
@@ -60,11 +60,13 @@ class TestWarcRecordTransformer:
         assert request.method == "GET"
 
     def test_response_for_record_invalid_response_type(self, warc_record_request):
+        request = Request("http://example.com")
         with pytest.raises(WaczMiddlewareException):
-            record_transformer.response_for_record(warc_record_request)
+            record_transformer.response_for_record(warc_record_request, request)
 
     def test_response_for_record(self, warc_record_response):
-        response = record_transformer.response_for_record(warc_record_response)
+        request = Request("http://example.com")
+        response = record_transformer.response_for_record(warc_record_response, request)
         assert isinstance(response, HtmlResponse)
         assert response.url == "http://example.com"
         assert response.status == 200


### PR DESCRIPTION
Resolves #30 

Attach the WARC record to the request/response meta. This way the user can choose to attach source information when parsing an item.

* Adds WARC reference to `Request.meta` when crawling through the `WaczMiddleware` downloader middleware
* Adds WARC reference to `Request.meta` when exporting through the `WaczExporter` extension

Todo's
- [x] Provide a recipe for extracting this information during scraping to the documentation