### PR TITLE
Add settings to run a spider against previously generated archives

### DIFF
--- a/docs/advanced_usage.md
+++ b/docs/advanced_usage.md
@@ -108,3 +108,37 @@ class MyWaczSpider(Spider):
                 'wacz_uri': warc_meta.wacz_uri,
             }
 ```
+
+## Extending
+
+### Custom strategies
+
+You can extend `scrapy-webarchive` by adding your own custom file lookup strategy. This allows you to define a custom way to select files based on available file information (URI and last modified timestamp).
+
+To create a new strategy, define a class that implements the `FileLookupStrategy` interface and register it with `StrategyRegistry`.
+
+``` py title="strategies.py"
+from typing import List, Optional
+
+from scrapy_webarchive.models import FileInfo
+from scrapy_webarchive.strategies import StrategyRegistry
+
+
+@StrategyRegistry.register("custom")
+class CustomStrategy:
+    def find(self, files: List[FileInfo], target_time: float) -> Optional[str]:
+        # Logic goes here, should return a single URI or None. 
+        # For examples see scrapy_webarchive.strategies.
+```
+
+Once registered, you can use your strategy by setting `SW_WACZ_LOOKUP_STRATEGY` in your Scrapy settings:
+
+``` py title="settings.py"
+SW_WACZ_LOOKUP_STRATEGY = "custom"
+```
+
+If you're defining it inside a `strategies.py` module within your Scrapy project, it will be automatically discovered. Alternatively, you can imported it somewhere in your project, such as in your `settings.py` or `middlewares.py`:
+
+``` py title="settings.py"
+import my_project.custom_strategies
+```

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -63,3 +63,34 @@ SW_WACZ_CRAWL = True
 ```
 
 Setting to ignore original `start_requests`, just yield all responses found in WACZ. For more information see [Iterating a WACZ archive index](advanced_usage.md#iterating-a-wacz-archive-index).
+
+### `SW_WACZ_LOOKUP_STRATEGY`
+
+``` py title="settings.py"
+SW_WACZ_LOOKUP_STRATEGY = "after"
+```
+
+A setting that can be used in combination with `SW_EXPORT_URI` and `SW_WACZ_LOOKUP_TARGET` to automatically resolve the most relevant archive for scraping.
+
+Supported strategies include `after` and `before`. However, the implementation of custom strategies is also supported. See [Custom strategies](advanced_usage.md#custom-strategies).
+
+### `SW_WACZ_LOOKUP_TARGET`
+
+This setting is used in combination with `SW_WACZ_LOOKUP_STRATEGY` to determine the most relevant archive for scraping based on the specified time. The value must be an **ISO 8601** formatted timestamp (YYYY-MM-DDTHH:MM:SS), representing the preferred point in time for file selection.
+
+``` py title="settings.py"
+SW_WACZ_LOOKUP_TARGET = "2025-01-01T00:00:00"
+```
+
+#### How It Works
+
+When `SW_EXPORT_URI` is set, `SW_WACZ_LOOKUP_TARGET` helps locate the closest matching file based on time.
+The strategy defined in `SW_WACZ_LOOKUP_STRATEGY` determines how files are selected relative to this timestamp.
+All of them are required in order to enable this feature.
+
+⚠️ When `SW_WACZ_SOURCE_URI` is set, these settings won't have any effect.
+
+#### Example Scenarios
+
+- **`before` strategy**: Selects the file with the closest last modified date before or exactly at the given timestamp.
+- **`after` strategy**: Selects the file with the closest last modified date after or exactly at the given timestamp.

--- a/example/webarchive_example/strategies.py
+++ b/example/webarchive_example/strategies.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from typing import List, Optional
+from scrapy_webarchive.models import FileInfo
+from scrapy_webarchive.strategies import StrategyRegistry
+
+
+@StrategyRegistry.register("custom")
+class CustomStrategy:
+    def find(self, files: List[FileInfo], target: datetime) -> Optional[str]:
+        return files[0].uri if files else None

--- a/scrapy_webarchive/constants.py
+++ b/scrapy_webarchive/constants.py
@@ -1,0 +1,4 @@
+WARC_DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+TIMESTAMP_DT_FORMAT = "%Y%m%d%H%M%S"
+BUFF_SIZE = 1024 * 64
+WEBARCHIVE_META_KEY = "webarchive_warc"

--- a/scrapy_webarchive/downloadermiddlewares.py
+++ b/scrapy_webarchive/downloadermiddlewares.py
@@ -5,10 +5,10 @@ from scrapy.http.request import Request
 from scrapy.http.response import Response
 from scrapy.spiders import Spider
 
+from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
 from scrapy_webarchive.exceptions import WaczMiddlewareException
 from scrapy_webarchive.models import WarcMetadata
 from scrapy_webarchive.spidermiddlewares import BaseWaczMiddleware
-from scrapy_webarchive.utils import WEBARCHIVE_META_KEY
 from scrapy_webarchive.warc import record_transformer
 
 

--- a/scrapy_webarchive/extensions.py
+++ b/scrapy_webarchive/extensions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime
 from io import BytesIO
 from typing import Tuple
 
@@ -16,8 +15,14 @@ from scrapy.settings import Settings
 from twisted.internet.defer import Deferred
 from typing_extensions import Any, Dict, Protocol, Self, Type, Union, cast
 
+from scrapy_webarchive.constants import WARC_DT_FORMAT, WEBARCHIVE_META_KEY
 from scrapy_webarchive.models import WarcMetadata
-from scrapy_webarchive.utils import WARC_DT_FORMAT, WEBARCHIVE_META_KEY, get_formatted_dt_string, get_scheme_from_uri
+from scrapy_webarchive.utils import (
+    get_archive_uri_template_dt_variables,
+    get_formatted_dt_string,
+    get_scheme_from_uri,
+    is_uri_directory,
+)
 from scrapy_webarchive.wacz.creator import WaczFileCreator
 from scrapy_webarchive.warc import WarcFileWriter
 
@@ -82,7 +87,13 @@ class WaczExporter:
         if not self.settings.get("SW_EXPORT_URI"):
             raise NotConfigured("Missing SW_EXPORT_URI setting.")
         
-        if self.settings.get("SW_WACZ_SOURCE_URI"):
+        if any(
+            [
+                self.settings.get("SW_WACZ_SOURCE_URI"),
+                self.settings.get("SW_WACZ_LOOKUP_STRATEGY"),
+                self.settings.get("SW_WACZ_LOOKUP_TARGET"),
+            ]
+        ):
             raise NotConfigured("WACZ exporter is disabled when scraping from a WACZ archive.")
 
     def _retrieve_store_uri_and_wacz_fname(self) -> Tuple[str, Union[str, None]]:
@@ -93,7 +104,7 @@ class WaczExporter:
             **get_archive_uri_template_dt_variables(),
         )
 
-        if os.path.isdir(export_uri):
+        if is_uri_directory(export_uri):
             return export_uri, None
         else:
             export_uri, wacz_fname = os.path.split(export_uri)
@@ -176,14 +187,3 @@ class WaczExporter:
     @property
     def export_uri(self) -> str:
         return os.path.join(self.store_uri, self.wacz_creator.wacz_fname)
-
-
-def get_archive_uri_template_dt_variables() -> dict:
-    current_date = datetime.now()
-
-    return {
-        "year": current_date.strftime("%Y"),
-        "month": current_date.strftime("%m"),
-        "day": current_date.strftime("%d"),
-        "timestamp": current_date.strftime("%Y%m%d%H%M%S"),
-    }

--- a/scrapy_webarchive/extensions.py
+++ b/scrapy_webarchive/extensions.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from io import BytesIO
-from typing import Tuple
 
 from scrapy import Spider, signals
 from scrapy.crawler import Crawler
@@ -13,7 +12,7 @@ from scrapy.pipelines.files import FSFilesStore, FTPFilesStore, GCSFilesStore, S
 from scrapy.pipelines.media import MediaPipeline
 from scrapy.settings import Settings
 from twisted.internet.defer import Deferred
-from typing_extensions import Any, Dict, Protocol, Self, Type, Union, cast
+from typing_extensions import Any, Dict, Protocol, Self, Tuple, Type, Union, cast
 
 from scrapy_webarchive.constants import WARC_DT_FORMAT, WEBARCHIVE_META_KEY
 from scrapy_webarchive.models import WarcMetadata

--- a/scrapy_webarchive/models.py
+++ b/scrapy_webarchive/models.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from scrapy.http.response import Response
 
-from scrapy_webarchive.utils import WEBARCHIVE_META_KEY
+from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
 
 
 @dataclass
@@ -28,7 +28,7 @@ class WarcMetadata:
             "record_id": self.record_id,
             "wacz_uri": self.wacz_uri,
         }
-    
+
     @classmethod
     def from_response(cls, response: Response) -> Union["WarcMetadata", None]:
         """Create a WarcMetadata instance from a Scrapy response object."""
@@ -42,3 +42,17 @@ class WarcMetadata:
             return None
 
         return cls(**warc_meta)
+
+
+@dataclass
+class FileInfo:
+    uri: str
+    last_modified: float
+
+    def __repr__(self):
+        return f"FileInfo(uri={self.uri}, last_modified={self.last_modified})"
+
+    def __lt__(self, other):
+        if isinstance(other, FileInfo):
+            return self.last_modified < other.last_modified
+        return NotImplemented

--- a/scrapy_webarchive/models.py
+++ b/scrapy_webarchive/models.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
-from typing import Union
 
 from scrapy.http.response import Response
+from typing_extensions import Union
 
 from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
 

--- a/scrapy_webarchive/resolvers.py
+++ b/scrapy_webarchive/resolvers.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Protocol
 from urllib.parse import urlparse
 
 from scrapy.settings import Settings
+from typing_extensions import List, Protocol
 
 from scrapy_webarchive.models import FileInfo
 from scrapy_webarchive.wacz.storages import get_s3_client

--- a/scrapy_webarchive/resolvers.py
+++ b/scrapy_webarchive/resolvers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import List, Protocol

--- a/scrapy_webarchive/resolvers.py
+++ b/scrapy_webarchive/resolvers.py
@@ -1,0 +1,58 @@
+import re
+from pathlib import Path
+from typing import List, Protocol
+from urllib.parse import urlparse
+
+from scrapy.settings import Settings
+
+from scrapy_webarchive.models import FileInfo
+from scrapy_webarchive.wacz.storages import get_s3_client
+
+
+class FileResolver(Protocol):
+    def resolve(self) -> List[FileInfo]:
+        ...
+
+
+class S3FileResolver:
+    def __init__(self, s3_client, bucket: str, regex_pattern: re.Pattern):
+        self.s3_client = s3_client
+        self.bucket = bucket
+        self.pattern_regex = regex_pattern
+
+    def resolve(self) -> List[FileInfo]:
+        """Resolve files from S3 matching the given pattern."""
+
+        objects = self.s3_client.list_objects_v2(Bucket=self.bucket)
+        return [
+            FileInfo(uri=f"s3://{self.bucket}/{obj['Key']}", last_modified=obj['LastModified'].timestamp())
+            for obj in objects.get("Contents", [])
+            if self.pattern_regex.fullmatch(obj['Key'])
+        ]
+
+
+class LocalFileResolver:
+    def __init__(self, base_path: str, regex_pattern: re.Pattern):
+        self.base_path = Path(base_path)
+        self.pattern_regex = regex_pattern
+
+    def resolve(self) -> List[FileInfo]:
+        """Resolve local files based on regex pattern."""
+
+        return [
+            FileInfo(uri=f'file://{str(path)}', last_modified=path.stat().st_mtime)
+            for path in self.base_path.rglob("*")
+            if self.pattern_regex.fullmatch(str(path.relative_to(self.base_path))) and not path.is_dir()
+        ]
+
+
+def create_resolver(settings: Settings, base_path: str, regex_pattern: re.Pattern) -> FileResolver:
+    """Factory function to create the appropriate resolver based on the URI template."""
+
+    if base_path.startswith("s3://"):
+        s3_client = get_s3_client(settings)
+        parse_result = urlparse(base_path, allow_fragments=False)
+        regex_pattern = re.compile(parse_result.path.lstrip('/') + regex_pattern.pattern)
+        return S3FileResolver(s3_client=s3_client, bucket=parse_result.netloc, regex_pattern=regex_pattern)
+    else:
+        return LocalFileResolver(base_path=base_path, regex_pattern=regex_pattern)

--- a/scrapy_webarchive/spidermiddlewares.py
+++ b/scrapy_webarchive/spidermiddlewares.py
@@ -92,6 +92,9 @@ class BaseWaczMiddleware:
 
         # Edge case where the URI template does not contain any placeholders.
         if base_path == self._uri_template and not utils.is_uri_directory(self._uri_template):
+            # Export URI does not require scheme. Assume it is a local file path if no scheme is defined.
+            if self._uri_template.startswith("/"):
+                return [f"file://{self._uri_template}"]
             return [self._uri_template]
 
         regex_pattern = utils.build_regex_pattern(
@@ -121,7 +124,15 @@ class BaseWaczMiddleware:
     def _uri_template(self) -> Optional[str]:
         """Generates the search pattern based on the export URI format."""
 
-        return self.settings.get("SW_EXPORT_URI")
+        uri_template = self.settings.get("SW_EXPORT_URI")
+
+        if not uri_template:
+            return None
+        
+        if utils.is_uri_directory(uri_template):
+            uri_template += "{filename}"
+
+        return uri_template
 
     @property
     def _target_time(self) -> Optional[datetime]:

--- a/scrapy_webarchive/spidermiddlewares.py
+++ b/scrapy_webarchive/spidermiddlewares.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import List, Optional
 from urllib.parse import urlparse
 
 from scrapy import Request, Spider, signals
@@ -10,7 +9,7 @@ from scrapy.crawler import Crawler
 from scrapy.exceptions import NotConfigured
 from scrapy.settings import Settings
 from scrapy.statscollectors import StatsCollector
-from typing_extensions import Iterable, Self, Union
+from typing_extensions import Iterable, List, Optional, Self, Union
 
 from scrapy_webarchive.exceptions import WaczMiddlewareException
 from scrapy_webarchive.resolvers import create_resolver

--- a/scrapy_webarchive/strategies.py
+++ b/scrapy_webarchive/strategies.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from typing import Dict, List, Optional, Protocol, Type
+
+from scrapy_webarchive.models import FileInfo
+
+
+class FileLookupStrategy(Protocol):
+    def find(self, files: List[FileInfo], target: datetime) -> Optional[str]:
+        """Algorithm to find a file based on a target."""
+        ...
+
+
+class StrategyRegistry:
+    _strategies: Dict[str, Type[FileLookupStrategy]] = {}
+
+    @classmethod
+    def register(cls, name: str):
+        """Decorator to register a new strategy."""
+
+        def decorator(strategy_cls: Type[FileLookupStrategy]):
+            cls._strategies[name] = strategy_cls
+            return strategy_cls  # Ensure the class is returned for normal usage
+        return decorator
+
+    @classmethod
+    def get(cls, name: str) -> FileLookupStrategy:
+        """Retrieves a strategy instance by name."""
+
+        if name not in cls._strategies:
+            raise ValueError(f"Unknown strategy: {name}")
+        return cls._strategies[name]()
+
+
+@StrategyRegistry.register("before")
+class BeforeStrategy(FileLookupStrategy):
+    """Strategy to find the file that was last modified before the target time. Should match closest to the target."""
+
+    def find(self, files: List[FileInfo], target: datetime) -> Optional[str]:
+        sorted_files = sorted(files)
+        target_timestamp = target.timestamp()
+
+        for file in sorted_files:
+            if target_timestamp >= file.last_modified:
+                return file.uri
+
+        return None
+
+
+@StrategyRegistry.register("after")
+class AfterStrategy(FileLookupStrategy):
+    """Strategy to find the file that was last modified after the target time. Should match closest to the target."""
+
+    def find(self, files: List[FileInfo], target: datetime) -> Optional[str]:
+        sorted_files = sorted(files)
+        target_timestamp = target.timestamp()
+
+        for file in sorted_files:
+            if file.last_modified >= target_timestamp:
+                return file.uri
+
+        return None

--- a/scrapy_webarchive/strategies.py
+++ b/scrapy_webarchive/strategies.py
@@ -39,7 +39,7 @@ class BeforeStrategy(FileLookupStrategy):
     """Strategy to find the file that was last modified before the target time. Should match closest to the target."""
 
     def find(self, files: List[FileInfo], target: datetime) -> Optional[str]:
-        sorted_files = sorted(files)
+        sorted_files = sorted(files, reverse=True)
         target_timestamp = target.timestamp()
 
         for file in sorted_files:

--- a/scrapy_webarchive/strategies.py
+++ b/scrapy_webarchive/strategies.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional, Protocol, Type
+
+from typing_extensions import Dict, List, Optional, Protocol, Type
 
 from scrapy_webarchive.models import FileInfo
 

--- a/scrapy_webarchive/strategies.py
+++ b/scrapy_webarchive/strategies.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Dict, List, Optional, Protocol, Type
 

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Tuple
+from typing import IO, Dict, Tuple
 from urllib.parse import urlparse
 
-WARC_DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-TIMESTAMP_DT_FORMAT = "%Y%m%d%H%M%S"
-BUFF_SIZE = 1024 * 64
-WEBARCHIVE_META_KEY = "webarchive_warc"
+from scrapy_webarchive.constants import BUFF_SIZE
 
 logger = logging.getLogger(__name__)
+
 
 def get_formatted_dt_string(format: str) -> str:
     return datetime.now(timezone.utc).strftime(format)
@@ -51,3 +50,89 @@ def hash_stream(hash_type: str, stream: IO) -> Tuple[int, str]:
         hasher.update(chunk)
 
     return size, f"{hash_type}:{hasher.hexdigest()}"
+
+
+def parse_iso8601_datetime(time_str: str) -> datetime:
+    """Convert the target ISO time string to a datetime object."""
+
+    if not time_str:
+        return None
+
+    try:
+        return datetime.fromisoformat(time_str)
+    except ValueError:
+        raise ValueError(f"Invalid date format: {time_str}. Use ISO format (YYYY-MM-DDTHH:MM:SS).")
+
+
+def get_archive_uri_template_dt_variables() -> dict:
+    current_date = datetime.now()
+
+    return {
+        "year": current_date.strftime("%Y"),
+        "month": current_date.strftime("%m"),
+        "day": current_date.strftime("%d"),
+        "timestamp": current_date.strftime("%Y%m%d%H%M%S"),
+    }
+
+
+def get_placeholder_patterns() -> Dict[str, str]:
+    """Return a mapping of placeholders to their corresponding regex patterns."""
+
+    return {
+        "{year}": r"[0-9]{4}",
+        "{month}": r"[0-9]{2}",
+        "{day}": r"[0-9]{2}",
+        "{timestamp}": r"[0-9]+",
+    }
+
+
+def is_uri_directory(uri: str) -> bool:
+    """Check if the URI is a directory or a file."""
+
+    parsed = urlparse(uri)
+    scheme = parsed.scheme
+    path = parsed.path
+
+    if not scheme and uri.startswith("/"):
+        path = uri
+
+    last_part = path.rstrip("/").split("/")[-1]
+
+    if path.endswith("/"):
+        return True
+    elif "." in last_part:
+        return False
+    else:
+        return True
+
+
+def extract_base_from_uri_template(uri_template: str) -> str:
+    """Extract the static base path from a URI template before the first placeholder."""
+
+    first_placeholder_pos = uri_template.find("{")
+    if first_placeholder_pos == -1:
+        return uri_template
+
+    return uri_template[:first_placeholder_pos]
+
+
+def build_regex_pattern(uri_template: str, placeholder_patterns: Dict[str, str]) -> re.Pattern:
+    """Build and compile a regex pattern from a URI template with placeholders."""
+
+    first_placeholder_pos = uri_template.find("{")
+    if first_placeholder_pos == -1:
+        return re.compile(r'.*')
+
+    pattern_str = uri_template[first_placeholder_pos:]
+    for placeholder, regex in placeholder_patterns.items():
+        pattern_str = pattern_str.replace(placeholder, regex)
+
+    return re.compile(pattern_str)
+
+def split_path_regex(uri_template: str) -> Tuple[str, re.Pattern]:
+    """Split a URI template into a base path and a regex pattern for variable parts."""
+
+    placeholder_patterns = get_placeholder_patterns()
+    base_path = extract_base_from_uri_template(uri_template)
+    regex_pattern = build_regex_pattern(uri_template, placeholder_patterns)
+    return base_path, regex_pattern

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -85,6 +85,7 @@ def get_placeholder_patterns(spider_name: str) -> Dict[str, str]:
         "{day}": r"[0-9]{2}",
         "{timestamp}": r"[0-9]+",
         "{spider}": spider_name,
+        "{filename}": r"[^/\\]+\.wacz$",
     }
 
 
@@ -122,9 +123,6 @@ def build_regex_pattern(uri_template: str, placeholder_patterns: Dict[str, str])
     """Build and compile a regex pattern from a URI template with placeholders."""
 
     first_placeholder_pos = uri_template.find("{")
-    if first_placeholder_pos == -1:
-        return re.compile(r'.*')
-
     pattern_str = uri_template[first_placeholder_pos:]
     for placeholder, regex in placeholder_patterns.items():
         pattern_str = pattern_str.replace(placeholder, regex)

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -5,8 +5,9 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Dict, Optional, Tuple
 from urllib.parse import urlparse
+
+from typing_extensions import IO, Dict, Optional, Tuple
 
 from scrapy_webarchive.constants import BUFF_SIZE
 

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -76,7 +76,7 @@ def get_archive_uri_template_dt_variables() -> dict:
     }
 
 
-def get_placeholder_patterns() -> Dict[str, str]:
+def get_placeholder_patterns(spider_name: str) -> Dict[str, str]:
     """Return a mapping of placeholders to their corresponding regex patterns."""
 
     return {
@@ -84,6 +84,7 @@ def get_placeholder_patterns() -> Dict[str, str]:
         "{month}": r"[0-9]{2}",
         "{day}": r"[0-9]{2}",
         "{timestamp}": r"[0-9]+",
+        "{spider}": spider_name,
     }
 
 
@@ -129,11 +130,3 @@ def build_regex_pattern(uri_template: str, placeholder_patterns: Dict[str, str])
         pattern_str = pattern_str.replace(placeholder, regex)
 
     return re.compile(pattern_str)
-
-def split_path_regex(uri_template: str) -> Tuple[str, re.Pattern]:
-    """Split a URI template into a base path and a regex pattern for variable parts."""
-
-    placeholder_patterns = get_placeholder_patterns()
-    base_path = extract_base_from_uri_template(uri_template)
-    regex_pattern = build_regex_pattern(uri_template, placeholder_patterns)
-    return base_path, regex_pattern

--- a/scrapy_webarchive/utils.py
+++ b/scrapy_webarchive/utils.py
@@ -5,7 +5,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import IO, Dict, Tuple
+from typing import IO, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
 from scrapy_webarchive.constants import BUFF_SIZE
@@ -52,7 +52,7 @@ def hash_stream(hash_type: str, stream: IO) -> Tuple[int, str]:
     return size, f"{hash_type}:{hasher.hexdigest()}"
 
 
-def parse_iso8601_datetime(time_str: str) -> datetime:
+def parse_iso8601_datetime(time_str: str) -> Optional[datetime]:
     """Convert the target ISO time string to a datetime object."""
 
     if not time_str:

--- a/scrapy_webarchive/wacz/creator.py
+++ b/scrapy_webarchive/wacz/creator.py
@@ -12,12 +12,8 @@ from typing_extensions import IO, TYPE_CHECKING, Dict, List, Union
 
 from scrapy_webarchive import __version__ as scrapy_webarchive_version
 from scrapy_webarchive.cdxj import write_cdxj_index
-from scrapy_webarchive.utils import (
-    TIMESTAMP_DT_FORMAT,
-    WARC_DT_FORMAT,
-    get_formatted_dt_string,
-    hash_stream,
-)
+from scrapy_webarchive.constants import TIMESTAMP_DT_FORMAT, WARC_DT_FORMAT
+from scrapy_webarchive.utils import get_formatted_dt_string, hash_stream
 from scrapy_webarchive.wacz.constants import ARCHIVE_DIR, INDEXES_DIR, WACZ_VERSION
 from scrapy_webarchive.warc import WARCReader
 

--- a/scrapy_webarchive/wacz/creator.py
+++ b/scrapy_webarchive/wacz/creator.py
@@ -5,10 +5,9 @@ import io
 import json
 import os
 import zipfile
-from typing import Any
 
 from scrapy import __version__ as scrapy_version
-from typing_extensions import IO, TYPE_CHECKING, Dict, List, Union
+from typing_extensions import IO, TYPE_CHECKING, Any, Dict, List, Union
 
 from scrapy_webarchive import __version__ as scrapy_webarchive_version
 from scrapy_webarchive.cdxj import write_cdxj_index

--- a/scrapy_webarchive/wacz/wacz_file.py
+++ b/scrapy_webarchive/wacz/wacz_file.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import gzip
 from collections import defaultdict
 from io import BytesIO
-from typing import Tuple
 
-from typing_extensions import IO, Dict, Generator, List, Union
+from typing_extensions import IO, Dict, Generator, List, Tuple, Union
 from warc.warc import WARCRecord
 
 from scrapy_webarchive.cdxj import CdxjRecord

--- a/scrapy_webarchive/warc.py
+++ b/scrapy_webarchive/warc.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import socket
 import uuid
 from io import BytesIO
-from typing import Union
 from urllib.parse import urlparse
 
 from scrapy import __version__ as scrapy_version
 from scrapy.http.request import Request
 from scrapy.http.response import Response
 from scrapy.responsetypes import ResponseTypes
-from typing_extensions import List, Tuple
+from typing_extensions import List, Tuple, Union
 from warc import WARCReader as BaseWARCReader
 from warc.warc import WARCRecord
 from warcio.recordloader import ArcWarcRecord

--- a/scrapy_webarchive/warc.py
+++ b/scrapy_webarchive/warc.py
@@ -18,8 +18,9 @@ from warcio.statusandheaders import StatusAndHeaders
 from warcio.warcwriter import WARCWriter
 
 from scrapy_webarchive.cdxj import CdxjRecord
+from scrapy_webarchive.constants import TIMESTAMP_DT_FORMAT
 from scrapy_webarchive.exceptions import WaczMiddlewareException
-from scrapy_webarchive.utils import TIMESTAMP_DT_FORMAT, get_formatted_dt_string, header_lines_to_dict
+from scrapy_webarchive.utils import get_formatted_dt_string, header_lines_to_dict
 
 
 def generate_warc_fname(prefix: str) -> str:

--- a/tests/test_downloadermiddlewares.py
+++ b/tests/test_downloadermiddlewares.py
@@ -31,7 +31,7 @@ class BaseTestWaczMiddleware:
     @contextmanager
     def _middleware(self, **new_settings):
         settings = self._get_settings(**new_settings)
-        mw = WaczMiddleware(settings, self.crawler.stats)
+        mw = WaczMiddleware(settings, self.crawler.stats, self.spider.name)
         mw.spider_opened(self.spider)
         yield mw
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -24,7 +24,7 @@ class TestWaczCrawlMiddlewareWarc11:
     @contextmanager
     def _middleware(self, **new_settings):
         settings = self._get_settings(**new_settings)
-        mw = WaczCrawlMiddleware(settings, self.crawler.stats)
+        mw = WaczCrawlMiddleware(settings, self.crawler.stats, self.spider.name)
         mw.spider_opened(self.spider)
         yield mw
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,10 @@
+from dataclasses import asdict
+
 import pytest
 from scrapy.http import Request, Response
 
 from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
-from scrapy_webarchive.models import WarcMetadata
+from scrapy_webarchive.models import FileInfo, WarcMetadata
 
 
 class TestWarcMetadata:
@@ -45,3 +47,40 @@ class TestWarcMetadata:
 
         request = Request(url=url, meta=meta)
         return Response(url=url, request=request)
+
+
+def test_fileinfo_creation():
+    file_info = FileInfo(uri="archive.wacz", last_modified=123.456)
+    assert file_info.uri == "archive.wacz"
+    assert file_info.last_modified == 123.456
+
+    dict_repr = asdict(file_info)
+    assert dict_repr == {"uri": "archive.wacz", "last_modified": 123.456}
+
+
+def test_fileinfo_repr():
+    file_info = FileInfo(uri="archive.wacz", last_modified=123.456)
+    expected_repr = "FileInfo(uri=archive.wacz, last_modified=123.456)"
+    assert repr(file_info) == expected_repr
+
+
+def test_fileinfo_comparison_lt():
+    file1 = FileInfo(uri="file1.txt", last_modified=123.456)
+    file2 = FileInfo(uri="file2.txt", last_modified=789.123)
+    
+    assert file1 < file2
+    assert not file2 < file1
+
+
+def test_fileinfo_comparison_same_timestamp():
+    file1 = FileInfo(uri="file1.txt", last_modified=123.456)
+    file2 = FileInfo(uri="file2.txt", last_modified=123.456)
+    
+    assert not file1 < file2
+    assert not file2 < file1
+
+
+def test_fileinfo_comparison_invalid_type():
+    file_info = FileInfo(uri="archive.wacz", last_modified=123.456)
+    result = file_info.__lt__("invalid_type")
+    assert result == NotImplemented

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
 import pytest
 from scrapy.http import Request, Response
 
+from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
 from scrapy_webarchive.models import WarcMetadata
-from scrapy_webarchive.utils import WEBARCHIVE_META_KEY
 
 
 class TestWarcMetadata:

--- a/tests/test_resolvers.py
+++ b/tests/test_resolvers.py
@@ -1,0 +1,91 @@
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from freezegun import freeze_time
+
+from scrapy_webarchive.models import FileInfo
+from scrapy_webarchive.resolvers import LocalFileResolver, S3FileResolver, create_resolver
+
+
+@pytest.fixture
+def mock_s3_client():
+    return Mock()
+
+
+@pytest.fixture
+def sample_regex():
+    return re.compile(r".*\.wacz$")
+
+
+class TestS3FileResolver:
+    def test_resolve_with_matching_files(self, mock_s3_client, sample_regex):
+        mock_response = {
+            "Contents": [
+                {"Key": "archive_1.wacz", "LastModified": datetime(2025, 1, 1)},
+                {"Key": "archive_2.warc", "LastModified": datetime(2025, 1, 2)},
+                {"Key": "archive_3.wacz", "LastModified": datetime(2025, 1, 3)},
+            ]
+        }
+        mock_s3_client.list_objects_v2.return_value = mock_response
+
+        resolver = S3FileResolver(mock_s3_client, "scrapy-webarchive", sample_regex)
+        result = resolver.resolve()
+
+        expected = [
+            FileInfo(uri="s3://scrapy-webarchive/archive_1.wacz", last_modified=datetime(2025, 1, 1).timestamp()),
+            FileInfo(uri="s3://scrapy-webarchive/archive_3.wacz", last_modified=datetime(2025, 1, 3).timestamp()),
+        ]
+        
+        assert result == expected
+        mock_s3_client.list_objects_v2.assert_called_once_with(Bucket="scrapy-webarchive")
+
+    def test_resolve_no_contents(self, mock_s3_client, sample_regex):
+        mock_s3_client.list_objects_v2.return_value = {}
+        resolver = S3FileResolver(mock_s3_client, "scrapy-webarchive", sample_regex)
+
+        result = resolver.resolve()
+        assert result == []
+
+
+class TestLocalFileResolver:
+    @freeze_time("2025-01-01 12:00:00")
+    def test_resolve_with_matching_files(self, sample_regex, fs):
+        base_path = "/scrapy-webarchive"
+        fs.create_file(os.path.join(base_path, "archive_1.wacz"), contents="")
+        fs.create_file(os.path.join(base_path, "archive_2.warc"), contents="")
+        fs.create_file(os.path.join(base_path, "archive_3.wacz"), contents="")
+
+        resolver = LocalFileResolver(base_path, sample_regex)
+        result = resolver.resolve()
+
+        expected_last_modified = datetime(2025, 1, 1, 12).timestamp() # frozen time
+        expected = [
+            FileInfo(uri="file:///scrapy-webarchive/archive_1.wacz", last_modified=expected_last_modified),
+            FileInfo(uri="file:///scrapy-webarchive/archive_3.wacz", last_modified=expected_last_modified),
+        ]
+        assert result == expected
+
+
+class TestCreateResolver:
+    @patch('scrapy_webarchive.resolvers.get_s3_client')
+    def test_create_s3_resolver(self, mock_get_s3_client, sample_regex):
+        mock_s3_client = Mock()
+        mock_get_s3_client.return_value = mock_s3_client
+
+        resolver = create_resolver({}, "s3://scrapy-webarchive/quotes/", sample_regex)
+
+        assert isinstance(resolver, S3FileResolver)
+        assert resolver.bucket == "scrapy-webarchive"
+        assert resolver.s3_client == mock_s3_client
+        assert resolver.pattern_regex.pattern == "quotes/.*\\.wacz$"
+
+    def test_create_local_resolver(self, sample_regex):
+        resolver = create_resolver({}, "/scrapy-webarchive", sample_regex)
+
+        assert isinstance(resolver, LocalFileResolver)
+        assert resolver.base_path == Path("/scrapy-webarchive")
+        assert resolver.pattern_regex == sample_regex

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+
+import pytest
+from typing_extensions import List
+
+from scrapy_webarchive.models import FileInfo
+from scrapy_webarchive.strategies import AfterStrategy, BeforeStrategy, StrategyRegistry
+
+
+@pytest.fixture
+def sample_files() -> List[FileInfo]:
+    return [
+        FileInfo("archive_1.wacz", datetime(2025, 1, 1).timestamp()),
+        FileInfo("archive_2.wacz", datetime(2025, 6, 1).timestamp()),
+        FileInfo("archive_3.wacz", datetime(2025, 12, 1).timestamp()),
+    ]
+
+
+@pytest.mark.parametrize("strategy_name", ["before", "after"])
+def test_strategy_registry_register_defaults(strategy_name):
+    assert strategy_name in StrategyRegistry._strategies
+
+
+@pytest.mark.parametrize("strategy_name, strategy_cls", [
+    ("before", BeforeStrategy),
+    ("after", AfterStrategy),
+])
+def test_strategy_registry_get_valid(strategy_name, strategy_cls):
+    strategy = StrategyRegistry.get(strategy_name)
+    assert isinstance(strategy, strategy_cls)
+
+
+def test_strategy_registry_get_invalid():
+    with pytest.raises(ValueError, match="Unknown strategy: invalid"):
+        StrategyRegistry.get("invalid")
+
+
+def test_strategy_registry_new_registration():
+    StrategyRegistry._strategies.clear()
+    
+    class NewStrategy():
+        pass
+    
+    StrategyRegistry.register("new")(NewStrategy)
+    assert StrategyRegistry._strategies["new"] == NewStrategy
+
+
+@pytest.mark.parametrize(
+    "strategy, target_date, files_input, expected_result",
+    [
+        (BeforeStrategy(), datetime(2025, 7, 1), "sample_files", "archive_2.wacz"),
+        (BeforeStrategy(), datetime(2024, 12, 1), "sample_files", None),
+        (BeforeStrategy(), datetime(2025, 7, 1), [], None),
+        (BeforeStrategy(), datetime(2025, 6, 1), "sample_files", "archive_2.wacz"),
+        (AfterStrategy(), datetime(2025, 3, 1), "sample_files", "archive_2.wacz"),
+        (AfterStrategy(), datetime(2026, 1, 1), "sample_files", None),
+        (AfterStrategy(), datetime(2025, 7, 1), [], None),
+        (AfterStrategy(), datetime(2025, 6, 1), "sample_files", "archive_2.wacz"),
+    ],
+    ids=[
+        "before_finds_file_before_target",
+        "before_no_file_before_target",
+        "before_empty_list",
+        "before_exact_match",
+        "after_finds_file_after_target",
+        "after_no_file_after_target",
+        "after_empty_list",
+        "after_exact_match",
+    ]
+)
+def test_strategy_find(strategy, target_date, files_input, expected_result, sample_files):
+    files = sample_files if files_input == "sample_files" else files_input
+    result = strategy.find(files, target_date)
+
+    if isinstance(result, dict):
+        result = result.get('name')
+
+    assert result == expected_result

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,13 +91,6 @@ def test_extract_base_from_uri_template(uri_template: str, expected: str):
     assert result == expected
 
 
-def test_build_regex_pattern_no_placeholders():
-    uri_template = "s3://scrapy-webarchive/"
-    result = utils.build_regex_pattern(uri_template, utils.get_placeholder_patterns(spider_name="quotes"))
-    assert result.pattern == r".*"
-    assert isinstance(result, re.Pattern)
-
-
 def test_build_regex_pattern_with_placeholders():
     uri_template = "s3://scrapy-webarchive/{spider}/{year}/{month}/{day}/{timestamp}/"
     result = utils.build_regex_pattern(uri_template, utils.get_placeholder_patterns(spider_name="quotes"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,53 +1,161 @@
 import hashlib
 import io
+import re
+from unittest.mock import patch
 
 import pytest
 
-from scrapy_webarchive.utils import BUFF_SIZE, hash_stream
+from scrapy_webarchive import utils
+from scrapy_webarchive.constants import BUFF_SIZE
 
 
 def test_hash_stream_with_empty_stream():
-    # Test with an empty stream
     data = b""
     stream = io.BytesIO(data)
-    size, result = hash_stream("sha256", stream)
+    size, result = utils.hash_stream("sha256", stream)
     
     assert size == 0
     assert result == f"sha256:{hashlib.sha256(data).hexdigest()}"
+
 
 def test_hash_stream_with_md5_algorithm():
     data = b"Hello world"
     expected_hash = hashlib.md5(data).hexdigest()
     
     stream = io.BytesIO(data)
-    size, result = hash_stream("md5", stream)
+    size, result = utils.hash_stream("md5", stream)
     
     assert size == len(data)
     assert result == f"md5:{expected_hash}"
+
 
 def test_hash_stream_with_sha256_algorithm():
     data = b"Hello world"
     expected_hash = hashlib.sha256(data).hexdigest()
     
     stream = io.BytesIO(data)
-    size, result = hash_stream("sha256", stream)
+    size, result = utils.hash_stream("sha256", stream)
     
     assert size == len(data)
     assert result == f"sha256:{expected_hash}"
+
 
 def test_hash_stream_with_unsupported_hash_type():
     data = b"Hello world"
     stream = io.BytesIO(data)
 
     with pytest.raises(ValueError):
-        hash_stream("unsupported_hash", stream)
+        utils.hash_stream("unsupported_hash", stream)
+
 
 def test_hash_stream_with_large_stream():
     data = b"a" * (2 * BUFF_SIZE)  # Twice the buffer size
     expected_hash = hashlib.sha256(data).hexdigest()
     
     stream = io.BytesIO(data)
-    size, result = hash_stream("sha256", stream)
+    size, result = utils.hash_stream("sha256", stream)
     
     assert size == len(data)
     assert result == f"sha256:{expected_hash}"
+
+
+MOCK_PLACEHOLDER_PATTERNS = {
+    "{year}": r"[0-9]{4}",
+    "{month}": r"[0-9]{2}",
+    "{day}": r"[0-9]{2}",
+    "{timestamp}": r"[0-9]+",
+}
+
+@pytest.mark.parametrize("uri, expected", [
+    # Directories
+    ("s3://scrapy-webarchive/quotes/", True),
+    ("s3://scrapy-webarchive/quotes", True),
+    ("/scrapy/webarchive/", True),
+    ("scrapy/webarchive/", True),
+    ("/scrapy-webarchive", True),
+
+    # Files
+    ("s3://scrapy-webarchive/quotes/archive.wacz", False),
+    ("s3://scrapy-webarchive/archive.wacz", False),
+    ("/scrapy/webarchive/archive.wacz", False),
+])
+def test_is_uri_directory(uri: str, expected: bool):
+    assert utils.is_uri_directory(uri) == expected
+
+
+@pytest.mark.parametrize("uri_template, expected", [
+    ("s3://scrapy-webarchive/{year}/quotes/{day}/res-{timestamp}.wacz", "s3://scrapy-webarchive/"),
+    ("s3://scrapy-webarchive/quotes/{year}/{month}/{day}/res-{timestamp}.wacz", "s3://scrapy-webarchive/quotes/"),
+    ("s3://scrapy-webarchive/", "s3://scrapy-webarchive/"),
+    ("file:///scrapy/{year}/quotes/{day}/res-{timestamp}.wacz", "file:///scrapy/"),
+    ("file:///scrapy/webarchive/{year}/", "file:///scrapy/webarchive/"),
+    ("file:///scrapy/webarchive/", "file:///scrapy/webarchive/"),
+    ("/scrapy/{year}/quotes/{day}/res-{timestamp}.wacz", "/scrapy/"),
+    ("/scrapy/webarchive/{spider}/", "/scrapy/webarchive/"),
+    ("/scrapy/webarchive/", "/scrapy/webarchive/"),
+])
+def test_extract_base_from_uri_template(uri_template: str, expected: str):
+    result = utils.extract_base_from_uri_template(uri_template)
+    assert result == expected
+
+
+def test_build_regex_pattern_no_placeholders():
+    uri_template = "s3://scrapy-webarchive/"
+    result = utils.build_regex_pattern(uri_template, MOCK_PLACEHOLDER_PATTERNS)
+    assert result.pattern == r".*"
+    assert isinstance(result, re.Pattern)
+
+
+def test_build_regex_pattern_with_placeholders():
+    uri_template = "s3://scrapy-webarchive/{year}/{month}/{day}/"
+    result = utils.build_regex_pattern(uri_template, MOCK_PLACEHOLDER_PATTERNS)
+
+    assert result.pattern == "[0-9]{4}/[0-9]{2}/[0-9]{2}/"
+    assert isinstance(result, re.Pattern)
+
+    assert result.match("2025/01/01/")
+    assert not result.match("01/01/2025/")
+
+
+@pytest.fixture
+def mock_placeholder_patterns():
+    with patch('scrapy_webarchive.utils.get_placeholder_patterns', return_value=MOCK_PLACEHOLDER_PATTERNS):
+        yield
+
+
+def test_split_path_regex_no_placeholders(mock_placeholder_patterns):
+    uri_template = "s3://scrapy-webarchive/"
+    base_path, regex_pattern = utils.split_path_regex(uri_template)
+    assert base_path == "s3://scrapy-webarchive/"
+    assert regex_pattern.pattern == r".*"
+    assert isinstance(regex_pattern, re.Pattern)
+
+
+def test_split_path_regex_with_placeholders(mock_placeholder_patterns):
+    uri_template = "s3://scrapy-webarchive/{year}/{month}/{day}/"
+    base_path, regex_pattern = utils.split_path_regex(uri_template)
+    assert base_path == "s3://scrapy-webarchive/"
+    assert regex_pattern.pattern == "[0-9]{4}/[0-9]{2}/[0-9]{2}/"
+    assert isinstance(regex_pattern, re.Pattern)
+
+@pytest.mark.parametrize("uri_template, expected_base, expected_pattern", [
+    (
+        "s3://scrapy-webarchive/{year}/{month}/{day}/",
+        "s3://scrapy-webarchive/",
+        "[0-9]{4}/[0-9]{2}/[0-9]{2}/",
+    ),
+    (
+        "s3://scrapy-webarchive/{year}/quotes/{month}/{day}/",
+        "s3://scrapy-webarchive/",
+        "[0-9]{4}/quotes/[0-9]{2}/[0-9]{2}/",
+    ),
+    (
+        "s3://scrapy-webarchive/",
+        "s3://scrapy-webarchive/",
+        r".*"
+    ),
+])
+def test_split_path_regex_parametrized(mock_placeholder_patterns, uri_template, expected_base, expected_pattern):
+    base_path, regex_pattern = utils.split_path_regex(uri_template)
+    assert base_path == expected_base
+    assert regex_pattern.pattern == expected_pattern

--- a/tests/wacz/test_wacz.py
+++ b/tests/wacz/test_wacz.py
@@ -1,11 +1,11 @@
 import zipfile
 from io import BytesIO
-from typing import cast
 from unittest.mock import Mock
 
 import pytest
 from freezegun import freeze_time
 from scrapy import __version__ as scrapy_version
+from typing_extensions import cast
 
 from scrapy_webarchive import __version__ as scrapy_webarchive_version
 from scrapy_webarchive.extensions import FilesStoreProtocol


### PR DESCRIPTION
Implements #29 

- [x] Document setting usage/behaviour
- [x] Make the strategies extendable (they are not detected when implemented by a third party, unless writing in a file that is executed/imported)
- [x] Add unit-tests for resolvers and strategies
- [x] Test functionality with different cases of local and s3 paths