### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,25 +37,40 @@ jobs:
           - py312-scrapy210
           - py38-scrapy211
           - py312-scrapy211
-          - py312-scrapymaster
+          - py39-scrapy212
+          - py313-scrapy212
+          - py39-scrapy213
+          - py313-scrapy213
+          - py313-scrapymaster
         include:
+          # Scrapy 2.9
           - toxenv: py37-scrapy29
             python-version: 3.7
           - toxenv: py312-scrapy29
             python-version: '3.12'
-
+          # Scrapy 2.10
           - toxenv: py38-scrapy210
             python-version: 3.8 
           - toxenv: py312-scrapy210
             python-version: '3.12'
-
+          # Scrapy 2.11
           - toxenv: py38-scrapy211
             python-version: 3.8 
           - toxenv: py312-scrapy211
             python-version: '3.12'
-
-          - toxenv: py312-scrapymaster
-            python-version: '3.12'
+          # Scrapy 2.12
+          - toxenv: py39-scrapy212
+            python-version: 3.9
+          - toxenv: py313-scrapy212
+            python-version: '3.13'
+          # Scrapy 2.13
+          - toxenv: py39-scrapy213
+            python-version: 3.9
+          - toxenv: py313-scrapy213
+            python-version: '3.13'
+          # Scrapy master
+          - toxenv: py313-scrapymaster
+            python-version: '3.13'
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Maintenance
 
 - Support for Python 3.12 and 3.13
-- Support for Scrapy 2.12 and 3.13
+- Support for Scrapy 2.12 and 2.13
 - Bumped `cdxj-indexer` to 1.4.6 (to support Python 3.13)
+- Added async `process_start` to spidermiddleware (to support Scrapy 2.13)
+    - Added additional async methods to support this (async iterator in WaczFile)
 
 ### Added
 - `py.typed` file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [next] - xxxx-xx-xx
 
+### Maintenance
+
+- Support for Python 3.12 and 3.13
+- Support for Scrapy 2.12 and 3.13
+- Bumped `cdxj-indexer` to 1.4.6 (to support Python 3.13)
+
+### Added
+- `py.typed` file
+
 
 ## [0.4.0] - 2025-02-28
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Scrapy Webarchive is a plugin for Scrapy that allows users to capture and export
 
 ## Compatibility
 
-* Python 3.7, 3.8, 3.9, 3.10, 3.11 and 3.12
+* Python 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 and 3.13
 
 ## Documentation
 

--- a/example/webarchive_example/strategies.py
+++ b/example/webarchive_example/strategies.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import List, Optional
+
 from scrapy_webarchive.models import FileInfo
 from scrapy_webarchive.strategies import StrategyRegistry
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ build-backend = "setuptools.build_meta"
 name = "scrapy-webarchive"
 version = "0.4.0"
 dependencies = [
-    "Scrapy>=2.9,<2.12",
+    "Scrapy>=2.9,<2.14",
     "warcio==1.7.4",
     "warc-knot==0.2.5",
     "wacz==0.5.0",
-    "cdxj-indexer==1.4.5",
+    "cdxj-indexer==1.4.6",
 ]
-requires-python = ">=3.7,<3.13"
+requires-python = ">=3.7,<3.14"
 authors = []
 maintainers = []
 description = "A webarchive extension for Scrapy"

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 -e .
 pytest>=7.4,<8.4
+pytest-twisted==1.14.3
 freezegun==1.5.1
 mypy>=1.4,<1.12
 ruff==0.6.8

--- a/scrapy_webarchive/extensions.py
+++ b/scrapy_webarchive/extensions.py
@@ -71,11 +71,14 @@ class WaczExporter:
         # Initialize store, writer and creator
         self.store: FilesStoreProtocol = self._get_store(self.store_uri)
         self.writer = WarcFileWriter(collection_name=self.spider_name)
+        collection_name = (
+            crawler.spidercls.name if hasattr(crawler.spidercls, "name") else getattr(crawler.spider, "name")
+        )
         self.wacz_creator = WaczFileCreator(
             store=self.store,
             warc_fname=self.writer.warc_fname,
             wacz_fname=self.wacz_fname,
-            collection_name=crawler.spider.name,
+            collection_name=collection_name,
             title=self.settings["SW_WACZ_TITLE"],
             description=self.settings["SW_WACZ_DESCRIPTION"],
         )
@@ -182,6 +185,7 @@ class WaczExporter:
 
     def spider_closed(self, spider: Spider) -> None:
         self.wacz_creator.create()
+        spider.logger.info(f"WACZ file created: {self.export_uri}")
 
     @property
     def export_uri(self) -> str:

--- a/scrapy_webarchive/spidermiddlewares.py
+++ b/scrapy_webarchive/spidermiddlewares.py
@@ -173,16 +173,17 @@ class WaczCrawlMiddleware(BaseWaczMiddleware):
         url = entry.data["url"]
         flags = []
 
-        if self.crawler.spider:
-            if self._is_off_site(url, self.crawler.spider):
-                self.stats.inc_value("webarchive/crawl_skip/off_site", spider=self.crawler.spider)
-                flags = ["wacz_start_request", "wacz_crawl_skip"]
-            elif self._is_disallowed_by_spider(url, self.crawler.spider):
-                self.stats.inc_value("webarchive/crawl_skip/disallowed", spider=self.crawler.spider)
-                flags = ["wacz_start_request", "wacz_crawl_skip"]
-            else:
-                self.stats.inc_value("webarchive/start_request_count", spider=self.crawler.spider)
-                flags = ["wacz_start_request"]
+        assert self.crawler.spider
+
+        if self._is_off_site(url, self.crawler.spider):
+            self.stats.inc_value("webarchive/crawl_skip/off_site", spider=self.crawler.spider)
+            flags = ["wacz_start_request", "wacz_crawl_skip"]
+        elif self._is_disallowed_by_spider(url, self.crawler.spider):
+            self.stats.inc_value("webarchive/crawl_skip/disallowed", spider=self.crawler.spider)
+            flags = ["wacz_start_request", "wacz_crawl_skip"]
+        else:
+            self.stats.inc_value("webarchive/start_request_count", spider=self.crawler.spider)
+            flags = ["wacz_start_request"]
 
         return record_transformer.request_for_record(
             entry,
@@ -199,8 +200,6 @@ class WaczCrawlMiddleware(BaseWaczMiddleware):
         Scrapy <2.13.
         """
 
-        assert self.crawler.spider
-
         if not self.crawl:
             yield from start
             return
@@ -213,8 +212,6 @@ class WaczCrawlMiddleware(BaseWaczMiddleware):
 
     async def process_start(self, start: AsyncIterator[Any]) -> AsyncIterator[Any]:
         """Processes start requests asynchronously."""
-
-        assert self.crawler.spider
 
         if not self.crawl:
             async for request in start:

--- a/scrapy_webarchive/spidermiddlewares.py
+++ b/scrapy_webarchive/spidermiddlewares.py
@@ -39,7 +39,7 @@ class BaseWaczMiddleware:
     @classmethod
     def from_crawler(cls, crawler: Crawler) -> Self:
         assert crawler.stats
-        spider_name = crawler.spidercls.name if hasattr(crawler.spidercls, "name") else crawler.spider.name
+        spider_name = crawler.spidercls.name if hasattr(crawler.spidercls, "name") else getattr(crawler.spider, "name")
         o = cls(crawler.settings, crawler.stats, spider_name)
         crawler.signals.connect(o.spider_opened, signals.spider_opened)
         return o
@@ -113,12 +113,14 @@ class BaseWaczMiddleware:
     def _is_off_site(self, url: str, spider: Spider) -> bool:
         """Check if the URL is off-site based on allowed domains."""
 
-        return hasattr(spider, "allowed_domains") and urlparse(url).hostname not in spider.allowed_domains
+        allowed_domains = getattr(spider, "allowed_domains", None)
+        return allowed_domains is not None and urlparse(url).hostname not in allowed_domains
 
     def _is_disallowed_by_spider(self, url: str, spider: Spider) -> bool:
         """Check if the URL is disallowed by the spider's archive rules."""
 
-        return hasattr(spider, "archive_disallow_regexp") and not re.search(spider.archive_disallow_regexp, url)
+        archive_disallow_regexp = getattr(spider, "archive_disallow_regexp", None)
+        return archive_disallow_regexp is not None and not re.search(archive_disallow_regexp, url)
 
     @property
     def _uri_template(self) -> Optional[str]:

--- a/scrapy_webarchive/wacz/wacz_file.py
+++ b/scrapy_webarchive/wacz/wacz_file.py
@@ -4,7 +4,7 @@ import gzip
 from collections import defaultdict
 from io import BytesIO
 
-from typing_extensions import IO, Dict, Generator, List, Tuple, Union
+from typing_extensions import IO, AsyncGenerator, Dict, Generator, List, Tuple, Union
 from warc.warc import WARCRecord
 
 from scrapy_webarchive.cdxj.models import CdxjRecord
@@ -64,6 +64,13 @@ class WaczFile:
 
     def iter_index(self) -> Generator[CdxjRecord, None, None]:
         """Iterates over all CDXJ records in the WACZ index."""
+
+        for cdxj_records in self.index.values():
+            for cdxj_record in cdxj_records:
+                yield cdxj_record
+
+    async def aiter_index(self) -> AsyncGenerator[CdxjRecord, None]:
+        """Asynchronously iterates over all CDXJ records in the WACZ index."""
 
         for cdxj_records in self.index.values():
             for cdxj_record in cdxj_records:
@@ -132,3 +139,10 @@ class MultiWaczFile:
         """
 
         yield from (cdxj_record for wacz in self.waczs for cdxj_record in wacz.iter_index())
+
+    async def aiter_index(self) -> AsyncGenerator[CdxjRecord, None]:
+        """Asynchronously iterates over the index entries in all WACZ files."""
+
+        for wacz in self.waczs:
+            async for cdxj_record in wacz.aiter_index():
+                yield cdxj_record

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,3 +15,8 @@ WARC-Target-URI: http://example.com/\r\n\
 Helloworld\
 \r\n\r\n\
 "
+
+
+def pytest_configure(config):
+    # install the reactor explicitly
+    from twisted.internet import reactor  # noqa: F401

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -24,7 +24,7 @@ class TestWaczCrawlMiddlewareWarc11:
     @contextmanager
     def _middleware(self, **new_settings):
         settings = self._get_settings(**new_settings)
-        mw = WaczCrawlMiddleware(settings, self.crawler.stats, self.spider.name)
+        mw = WaczCrawlMiddleware(settings, getattr(self.crawler, "stats"), self.spider.name)
         mw.spider_opened(self.spider)
         yield mw
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,7 @@ from dataclasses import asdict
 
 import pytest
 from scrapy.http import Request, Response
+from typing_extensions import Optional
 
 from scrapy_webarchive.constants import WEBARCHIVE_META_KEY
 from scrapy_webarchive.models import FileInfo, WarcMetadata
@@ -41,7 +42,7 @@ class TestWarcMetadata:
         with pytest.raises(TypeError):
             WarcMetadata.from_response(response)
     
-    def _get_response(self, meta: dict = None, url: str = "https://example.com"):
+    def _get_response(self, meta: Optional[dict] = None, url: str = "https://example.com"):
         if meta is None:
             meta = {WEBARCHIVE_META_KEY: self.meta}
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@ usedevelop = True
 envlist =
     py{37,38,39,310,311,312}-scrapy29,
     py{38,39,310,311,312}-scrapy{210,211},
-    py{39,310,311,312}-scrapymaster,
+    py{39,310,311,312,313}-scrapy{212,213},
+    py{39,310,311,312,313}-scrapymaster,
 
 [testenv]
 install_command = pip install -r requirements-tests.txt
@@ -19,8 +20,11 @@ basepython =
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 deps =
     scrapy29: Scrapy~=2.9.0
     scrapy210: Scrapy~=2.10.0
     scrapy211: Scrapy~=2.11.0
+    scrapy212: Scrapy~=2.12.0
+    scrapy213: Scrapy~=2.13.0
     scrapymaster: git+https://github.com/scrapy/scrapy.git@master#egg=Scrapy


### PR DESCRIPTION
- [x] Support for Python 3.13
- [x] Support for Scrapy 2.12 & 2.13
- [x] Bump `cdxj-indexer` to 1.4.6 (Python 3.13 compatibility)
- [x] Added `py.typed` file
- [x] Fix Scrapy 2.13 deprecation: [Spider middlewares that don’t support asynchronous spider output](https://docs.scrapy.org/en/latest/topics/coroutines.html#sync-async-spider-middleware) are deprecated